### PR TITLE
Changed CME to NXC

### DIFF
--- a/Active Directory Pentesting/README.md
+++ b/Active Directory Pentesting/README.md
@@ -122,8 +122,8 @@
 - [BloodHound](https://github.com/BloodHoundAD/BloodHound)
 - [Mimikatz](https://github.com/gentilkiwi/mimikatz)
 - [Responder](https://github.com/lgandx/Responder)
-- [CrackMapExec (CME)](https://github.com/byt3bl33d3r/CrackMapExec)
-- [PowerShell Empire](https://github.com/Emp
+- [NetExec (NXC)](https://github.com/Pennyw0rth/NetExec)
+- [PowerShell Empire](https://github.com/Emp)
 
 ---
 ---
@@ -348,7 +348,7 @@
 ### 16. Lateral Movement
 
 - [ ] Attempt lateral movement through SMB, WMI, or remote desktop.
-  - **Tools:** [CrackMapExec (CME)](https://github.com/byt3bl33d3r/CrackMapExec), [PowerShell Empire](https://github.com/EmpireProject/Empire)
+  - **Tools:** [NetExec (NXC)](https://github.com/Pennyw0rth/NetExec), [PowerShell Empire](https://github.com/EmpireProject/Empire)
   - **Command:** Varies based on the tool
 
 - [ ] Escalate privileges on compromised systems.


### PR DESCRIPTION
As CME is no longer maintained, NXC which is a fork of CME with new features, should be used as a replacement.